### PR TITLE
Alias motion_require to require_relative

### DIFF
--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -35,7 +35,7 @@ Motion::Project::Config.send(:include, Motion::Require::Ext::ConfigTask)
 module Motion
   module Require
     class RequireBuilder < Ripper::SexpBuilder
-      REQUIREMENT_TOKEN = "motion_require"
+      REQUIREMENT_TOKENS = %w[motion_require require_relative]
 
       attr_accessor :requires
 
@@ -45,7 +45,7 @@ module Motion
 
       def on_command(command, args) # scanner event
         type, name, position = command
-        if name == REQUIREMENT_TOKEN
+        if REQUIREMENT_TOKENS.include?(name)
           file = parse_args(args)
           requires << file
         end

--- a/motion/ext.rb
+++ b/motion/ext.rb
@@ -3,4 +3,5 @@
 module Kernel
   def motion_require(*args)
   end
+  alias_method :require_relative, :motion_require
 end


### PR DESCRIPTION
I suspect you chose not to use `require_relative` for a reason. If you're against having a `require_relative` alias included by default, perhaps it could be still be supported but off by default, requiring the developer to explicitly enable it.
