### PR TITLE
Use RubyMotion's default project file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ end
 require 'motion/project'
 
 require 'motion-require'
-Motion::Require.all(Dir.glob("app/**/*.rb"))
+Motion::Require.all
 
 Motion::Project::App.setup do |app|
   # ...
@@ -25,6 +25,12 @@ end
 ```
 
 ![Whoa.](http://i.imgur.com/JLpjqkk.jpg)
+
+To enable `require_motion` for only select files:
+
+```ruby
+Motion::Require.all(Dir.glob('app/models/**/*.rb'))
+```
 
 It's used in:
 - [Formotion](https://github.com/clayallsopp/formotion)

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -97,11 +97,12 @@ module Motion
       File.join(File.dirname(source), required.to_str)
     end
 
-    def all(files)
+    # Scan specified files. When nil, fallback to RubyMotion's default (app/**/*.rb).
+    def all(files=nil)
       Motion::Project::App.setup do |app|
         app.files << ext_file
-        app.files |= files.map { |f| explicit_relative(f) }
-        dependencies = dependencies_for(files)
+        app.files |= Array(files).map { |f| explicit_relative(f) }
+        dependencies = dependencies_for(files || app.files)
         app.files_dependencies dependencies
       end
     end


### PR DESCRIPTION
Hey Clay,

RubyMotion's file list has a default file list of `app/**/*.rb`. This change removes the need to specify which files are scanned and just uses RubyMotion's defaults if no files are explicitly passed.

With this change, the following two invocations do the same:

``` ruby
Motion::Require.all(Dir.glob('app/**/*.rb'))
Motion::Require.all
```
