### PR TITLE
Raise LoadError for unresolved require's

### DIFF
--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -56,10 +56,17 @@ module Motion
         requires = requires_in(file_path)
         if !requires.empty?
           dependencies[file_path] = requires.map { |required|
-            if required[-3..-1] != ".rb"
-              required += ".rb"
+            required_path = resolve_path(file_path, required)
+            if !File.exist?(required_path) && File.extname(required) != ".rb"
+              required_path += ".rb"
             end
-            resolve_path(file_path, required)
+
+            if !File.exist?(required_path)
+              # TODO: Report line number of failing require
+              raise LoadError, "ERROR! In `#{file_path}', could not require `#{required}', file not found."
+            end
+
+            required_path
           }
           dependencies[file_path].unshift ext_file
         end


### PR DESCRIPTION
Prior to this change, RubyMotion's toolchain would report the error like so:

```
ERROR! Can't resolve dependency `app/file3.rb'
```

With this change, the error message is more helpful:

```
ERROR! In `./app/file1.rb', could not require `file3', file not found.
```

However, with this change, a stack trace is printed in the later case while
none is printed in the former.
