### PR TITLE
OS X support!

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ To enable `motion_require` for only select files:
 
 ```ruby
 Motion::Require.all(Dir.glob('app/models/**/*.rb'))
+
+# if you're writing a gem that supports iOS and OS X, you might need to filter
+# based on the platform:
+Motion::Require.all(Dir.glob('lib/ios/**/*.rb'), platform: :ios)
+Motion::Require.all(Dir.glob('lib/osx/**/*.rb'), platform: :osx)
 ```
 
 You **should not** use `app.files <<` in your `setup` block if using motion-require; opt to use `Motion::Require.all` and it will be taken care of.

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -94,11 +94,10 @@ module Motion
       end
 
       check_platform = options.fetch(:platform, nil)
+      current_platform = App.respond_to?(:template) ? App.template : :ios
+      return unless Motion::Require.check_platform(current_platform, check_platform)
 
       Motion::Project::App.setup do |app|
-        current_platform = app.respond_to?(:template) ? app.template : :ios
-        break unless Motion::Require.check_platform(current_platform, check_platform)
-
         app.exclude_from_detect_dependencies << ext_file
 
         if files.nil? || files.empty?

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -97,23 +97,23 @@ module Motion
 
       Motion::Project::App.setup do |app|
         current_platform = app.respond_to?(:template) ? app.template : :ios
-        if Motion::Require.check_platform(current_platform, check_platform)
-          app.exclude_from_detect_dependencies << ext_file
+        return unless Motion::Require.check_platform(current_platform, check_platform)
 
-          if files.nil? || files.empty?
-            app.files.push ext_file
-            app.exclude_from_detect_dependencies += app.files
-            app.files_dependencies dependencies_for(app.files.flatten)
-          else
-          # Place files prior to those in ./app, otherwise at the end.
-            preceding_app = app.files.index { |f| f =~ %r(^(?:\./)?app/) } || -1
-            required = Array(files).map { |f| explicit_relative(f) }
-            app.exclude_from_detect_dependencies += required
-            app.files.insert(preceding_app, ext_file, *required)
-            app.files.uniq! # Prevent redundancy
+        app.exclude_from_detect_dependencies << ext_file
 
-            app.files_dependencies dependencies_for(required)
-          end
+        if files.nil? || files.empty?
+          app.files.push ext_file
+          app.exclude_from_detect_dependencies += app.files
+          app.files_dependencies dependencies_for(app.files.flatten)
+        else
+        # Place files prior to those in ./app, otherwise at the end.
+          preceding_app = app.files.index { |f| f =~ %r(^(?:\./)?app/) } || -1
+          required = Array(files).map { |f| explicit_relative(f) }
+          app.exclude_from_detect_dependencies += required
+          app.files.insert(preceding_app, ext_file, *required)
+          app.files.uniq! # Prevent redundancy
+
+          app.files_dependencies dependencies_for(required)
         end
       end
     end

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -97,7 +97,7 @@ module Motion
 
       Motion::Project::App.setup do |app|
         current_platform = app.respond_to?(:template) ? app.template : :ios
-        return unless Motion::Require.check_platform(current_platform, check_platform)
+        break unless Motion::Require.check_platform(current_platform, check_platform)
 
         app.exclude_from_detect_dependencies << ext_file
 

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -86,8 +86,21 @@ module Motion
     end
 
     # Scan specified files. When nil, fallback to RubyMotion's default (app/**/*.rb).
-    def all(files=nil)
+    def all(files=nil, options={})
+      # if you want the default 'app.files', you can just pass in the options
+      if files.is_a?(Hash) && options == {}
+        options = files
+        files = nil
+      end
+
+      check_platform = options.fetch(:platform, nil)
+
       Motion::Project::App.setup do |app|
+        current_platform = app.respond_to?(:template) ? app.template : :ios
+        if check_platform && check_platform != current_platform
+          break
+        end
+
         app.exclude_from_detect_dependencies << ext_file
 
         if files.nil? || files.empty?

--- a/lib/motion-require.rb
+++ b/lib/motion-require.rb
@@ -97,26 +97,38 @@ module Motion
 
       Motion::Project::App.setup do |app|
         current_platform = app.respond_to?(:template) ? app.template : :ios
-        if check_platform && check_platform != current_platform
-          break
+        if Motion::Require.check_platform(current_platform, check_platform)
+          app.exclude_from_detect_dependencies << ext_file
+
+          if files.nil? || files.empty?
+            app.files.push ext_file
+            app.exclude_from_detect_dependencies += app.files
+            app.files_dependencies dependencies_for(app.files.flatten)
+          else
+          # Place files prior to those in ./app, otherwise at the end.
+            preceding_app = app.files.index { |f| f =~ %r(^(?:\./)?app/) } || -1
+            required = Array(files).map { |f| explicit_relative(f) }
+            app.exclude_from_detect_dependencies += required
+            app.files.insert(preceding_app, ext_file, *required)
+            app.files.uniq! # Prevent redundancy
+
+            app.files_dependencies dependencies_for(required)
+          end
         end
+      end
+    end
 
-        app.exclude_from_detect_dependencies << ext_file
-
-        if files.nil? || files.empty?
-          app.files.push ext_file
-          app.exclude_from_detect_dependencies += app.files
-          app.files_dependencies dependencies_for(app.files.flatten)
-        else
-        # Place files prior to those in ./app, otherwise at the end.
-          preceding_app = app.files.index { |f| f =~ %r(^(?:\./)?app/) } || -1
-          required = Array(files).map { |f| explicit_relative(f) }
-          app.exclude_from_detect_dependencies += required
-          app.files.insert(preceding_app, ext_file, *required)
-          app.files.uniq! # Prevent redundancy
-
-          app.files_dependencies dependencies_for(required)
-        end
+    def check_platform(current_platform, check_platform)
+      case check_platform
+      when nil
+        true
+      when Array
+        check_platform.include?(current_platform)
+      when Symbol
+        current_platform == check_platform
+      else
+        puts "Unrecognized value for 'check_platform': #{check_platform.inspect}"
+        false
       end
     end
 

--- a/spec/motion_require_spec.rb
+++ b/spec/motion_require_spec.rb
@@ -4,4 +4,20 @@ describe Motion::Require do
   it 'should run' do
     true.should == true
   end
+
+  describe 'should check_platform' do
+    it 'should support `nil`' do
+      Motion::Require.check_platform(:ios, nil).should == true
+    end
+    it 'should support Symbol' do
+      Motion::Require.check_platform(:ios, :ios).should == true
+      Motion::Require.check_platform(:ios, :osx).should == false
+    end
+    it 'should support Array' do
+      Motion::Require.check_platform(:ios, [:ios]).should == true
+      Motion::Require.check_platform(:ios, [:ios, :osx]).should == true
+      Motion::Require.check_platform(:osx, [:ios, :osx]).should == true
+      Motion::Require.check_platform(:ios, [:osx]).should == false
+    end
+  end
 end


### PR DESCRIPTION
And it's about damn time. This is for gems that are using MotionRequire

``` ruby
Motion::Require.all(...)  # include files regardless of platform
Motion::Require.all(..., platform: :ios)  # only include if the platform is iOS
Motion::Require.all(..., platform: :osx)  # only include if the platform is OS X
Motion::Require.all(..., platform: [:ios, :osx])  # why yes, this IS redundant!  I added it by accident, figured it was good for "completeness"
```

AND there are SPECS for this bad boy!
