### PR TITLE
Fix deprecated syntax for rspec > 3.1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rspec'
 require 'motion-require'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.color = true
   config.formatter     = 'documentation'
 end


### PR DESCRIPTION
While running tests with rspec>3.1 it fails due to ```NoMethodError: undefined method `color_enabled=' ``` This is because the  config options changed after rspec >3.1. This PR introduces changes so that this works when running tests with rspec > 3.1 .
I know you haven't been active for quite a long time. But I hope you'll include this in your next release :)